### PR TITLE
Implemented SystemD support

### DIFF
--- a/program/Core/Server/functions.sh
+++ b/program/Core/Server/functions.sh
@@ -76,7 +76,7 @@ Core.Server::requestStart () {
 
 	# LAUNCH! (in tmux)
 
-	tmux -f "$THIS_DIR/cfg/tmux.conf" -S "$SOCKET" new-session -n "server-control" -s "$APP@$INSTANCE" /bin/bash "$INSTANCE_DIR/msm.d/tmp/server-control.sh" \; detach
+	tmux -f "$THIS_DIR/cfg/tmux.conf" -S "$SOCKET" new-session -n "server-control" -s "$APP@$INSTANCE" -d /bin/bash "$INSTANCE_DIR/msm.d/tmp/server-control.sh" \; detach
 
 	success <<-EOF
 		**$INSTANCE_TEXT** started successfully!


### PR DESCRIPTION
Implemented [SystemD](https://systemd.io) by [Red Hat](https://www.redhat.com) support by adding the daemon flag to the [Tmux](https://github.com/tmux/tmux/wiki) by [Nicholas Marriott](https://github.com/nicm) launch command.

Without this change when starting the server via a [SystemD](https://systemd.io) service the server will fail to start.